### PR TITLE
[#198] Make nar implementation compatible with the original one

### DIFF
--- a/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
@@ -79,7 +79,7 @@ streamNarIO effs basePath yield = do
       yield $ int fSize
       yieldFile path fSize
 
-    when isDir $ do
+    when (isDir && not isSymLink) $ do
       fs <- IO.liftIO (Nar.narListDir effs path)
       yield $ strs ["type", "directory"]
       forM_ (sort fs) $ \f -> do


### PR DESCRIPTION
Problem: this implementation of nar made non-identical archives with the original implementation

Solution: doesn't treat the directory symlinks as they are directories

See https://github.com/haskell-nix/hnix-store/issues/198#issuecomment-1365911042 for the MRE